### PR TITLE
Include _super call in example of Addon.included

### DIFF
--- a/classes/Addon.html
+++ b/classes/Addon.html
@@ -1788,6 +1788,7 @@ would typically use this hook to perform additional imports</p>
 
         <h4>Example:</h4>
         <pre class="code prettyprint"><code class="language-js">included(parent) {
+  this._super.included.apply(this, arguments);
   this.import(somePath);
 }
 </code></pre>


### PR DESCRIPTION
Since [failing to call `this._super.included` can cause problems](https://github.com/brianhjelle/ember-plotly-shim/issues/1#issuecomment-371619744) I think it would be nice if the example showed this.